### PR TITLE
Update to Prisma 5

### DIFF
--- a/embeddings/package.json
+++ b/embeddings/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.37",
-    "prisma": "5.18.0",
+    "prisma": "5.19.1",
     "typescript": "^5.1.0",
     "vite": "^4.3.9"
   }

--- a/embeddings/package.json
+++ b/embeddings/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.37",
-    "prisma": "4.16.2",
+    "prisma": "5.18.0",
     "typescript": "^5.1.0",
     "vite": "^4.3.9"
   }

--- a/todo-ts/package.json
+++ b/todo-ts/package.json
@@ -8,6 +8,6 @@
     "typescript": "^5.1.0",
     "vite": "^4.3.9",
     "@types/react": "^18.0.37",
-    "prisma": "4.16.2"
+    "prisma": "5.18.0"
   }
 }

--- a/todo-ts/package.json
+++ b/todo-ts/package.json
@@ -8,6 +8,6 @@
     "typescript": "^5.1.0",
     "vite": "^4.3.9",
     "@types/react": "^18.0.37",
-    "prisma": "5.18.0"
+    "prisma": "5.19.1"
   }
 }


### PR DESCRIPTION
Bumps the Prisma version to v5 so it can be used with the upcoming Wasp release. 